### PR TITLE
[data.source_aws_vpc_peering_connection] - Add cidr block sets

### DIFF
--- a/aws/data_source_aws_vpc_peering_connection.go
+++ b/aws/data_source_aws_vpc_peering_connection.go
@@ -39,6 +39,18 @@ func dataSourceAwsVpcPeeringConnection() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"cidr_block_set": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"ipv6_cidr_block_set": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"region": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -58,6 +70,18 @@ func dataSourceAwsVpcPeeringConnection() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+			},
+			"peer_cidr_block_set": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"peer_ipv6_cidr_block_set": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 			"peer_region": {
 				Type:     schema.TypeString,
@@ -132,10 +156,14 @@ func dataSourceAwsVpcPeeringConnectionRead(d *schema.ResourceData, meta interfac
 	d.Set("vpc_id", pcx.RequesterVpcInfo.VpcId)
 	d.Set("owner_id", pcx.RequesterVpcInfo.OwnerId)
 	d.Set("cidr_block", pcx.RequesterVpcInfo.CidrBlock)
+	d.Set("cidr_block_set", pcx.RequesterVpcInfo.CidrBlockSet)
+	d.Set("ipv6_cidr_block_set", pcx.RequesterVpcInfo.CidrBlockSet)
 	d.Set("region", pcx.RequesterVpcInfo.Region)
 	d.Set("peer_vpc_id", pcx.AccepterVpcInfo.VpcId)
 	d.Set("peer_owner_id", pcx.AccepterVpcInfo.OwnerId)
 	d.Set("peer_cidr_block", pcx.AccepterVpcInfo.CidrBlock)
+	d.Set("peer_cidr_block_set", pcx.AccepterVpcInfo.CidrBlockSet)
+	d.Set("peer_ipv6_cidr_block_set", pcx.AccepterVpcInfo.Ipv6CidrBlockSet)
 	d.Set("peer_region", pcx.AccepterVpcInfo.Region)
 	d.Set("tags", tagsToMap(pcx.Tags))
 

--- a/aws/data_source_aws_vpc_peering_connection_test.go
+++ b/aws/data_source_aws_vpc_peering_connection_test.go
@@ -34,6 +34,7 @@ func TestAccDataSourceAwsVpcPeeringConnection_basic(t *testing.T) {
 					testAccDataSourceAwsVpcPeeringConnectionCheck("data.aws_vpc_peering_connection.test_by_owner_ids"),
 					resource.TestCheckResourceAttrSet("data.aws_vpc_peering_connection.test_by_owner_ids", "id"),
 					resource.TestCheckResourceAttrSet("data.aws_vpc_peering_connection.test_by_owner_ids", "cidr_block"),
+					resource.TestCheckResourceAttrSet("data.aws_vpc_peering_connection.test_by_owner_ids", "cidr_block_set"),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/website/docs/d/vpc_peering_connection.html.markdown
+++ b/website/docs/d/vpc_peering_connection.html.markdown
@@ -48,11 +48,21 @@ The given filters must match exactly one VPC peering connection whose data will 
 
 * `cidr_block` - (Optional) The CIDR block of the requester VPC of the specific VPC Peering Connection to retrieve.
 
+* `cidr_block_set` - (Optional) The list of CIDR blocks of the requester VPC of the specific VPC Peering Connection to retrieve.
+
+* `ipv6_cidr_block_set` - (Optional) The list of IPv6 CIDR blocks of the requester VPC of the specific VPC Peering Connection to retrieve.
+
 * `region` - (Optional) The region of the requester VPC of the specific VPC Peering Connection to retrieve.
 
 * `peer_vpc_id` - (Optional) The ID of the accepter VPC of the specific VPC Peering Connection to retrieve.
 
 * `peer_owner_id` - (Optional) The AWS account ID of the owner of the accepter VPC of the specific VPC Peering Connection to retrieve.
+
+* `peer_cidr_block` - (Optional) The CIDR block of the accepter VPC of the specific VPC Peering Connection to retrieve.
+
+* `peer_cidr_block_set` - (Optional) The list of CIDR blocks of the accepter VPC of the specific VPC Peering Connection to retrieve.
+
+* `peer_ipv6_cidr_block_set` - (Optional) The CIDR block of the accepter VPC of the specific VPC Peering Connection to retrieve.
 
 * `peer_cidr_block` - (Optional) The CIDR block of the accepter VPC of the specific VPC Peering Connection to retrieve.
 


### PR DESCRIPTION
The describe-vpc-peering-connections call returns a CidrBlockSet attr.
For Both AccepterVpcInfo and RequesterVpcInfo
Those attr could be useful for setting up security group with cidr source based rules
Or for setting up routes based on the cidr associated with the peering.

This PR add :
- "cidr_block_set"
- "ipv6_cidr_block_set"
- "peer_cidr_block_set"
- "peer_ipv6_cidr_block_set"
To the data_source aws_vpc_peering_connection
